### PR TITLE
New location for kubernetes-secret-env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,11 @@ RUN \
   rm node-v$NODE_VERSION-linux-x64.tar.gz
 
 # Install kubernetes-secret-env
-ENV KUBERNETES_SECRET_ENV_VERSION=0.0.1-rc0
+ENV KUBERNETES_SECRET_ENV_VERSION=0.0.1
 RUN \
   mkdir -p /etc/secret-volume && \
   cd /usr/local/bin && \
-  curl -sfLO https://github.com/buth/kubernetes-secret-env/releases/download/v$KUBERNETES_SECRET_ENV_VERSION/kubernetes-secret-env && \
+  curl -sfLO https://github.com/newsdev/kubernetes-secret-env/releases/download/$KUBERNETES_SECRET_ENV_VERSION/kubernetes-secret-env && \
   chmod +x kubernetes-secret-env
 
 # Set the working directory


### PR DESCRIPTION
Needs to be updated to use newsdev's version or the Docker build will fail next time it runs without a cache
