### PR TITLE
Remove newline from <a> open tag

### DIFF
--- a/lib/driveshaft/exports/archieml.rb
+++ b/lib/driveshaft/exports/archieml.rb
@@ -47,7 +47,7 @@ module Driveshaft
             href = parsed_url['q'][0] if parsed_url['q']
           end
 
-          str = "<a href=\"#{href}\">\n"
+          str = "<a href=\"#{href}\">"
           str += convert_node(node)
           str += "</a>"
           return str


### PR DESCRIPTION
This newline char was pushing everything after the <a> open tag onto a
separate line. In single-line values in ArchieML, that meant a link's
text and closing </a> tag would be lost.

Fixes #28